### PR TITLE
CSS微調整（note上でのマウスカーソルを変更）

### DIFF
--- a/_src/css/index.css
+++ b/_src/css/index.css
@@ -459,6 +459,9 @@ body {
 .key-detail {
   height: inherit;
   margin: auto;
+  .vf-stavenote {
+    cursor: pointer;
+  }
 }
 
 .staff-box {


### PR DESCRIPTION
ちょっとした変更です。ノートにマウスカーソルを乗せたときに再生できそう感を出します。

![notes-hover](https://user-images.githubusercontent.com/3132889/77141680-18787000-6ac1-11ea-9668-4ba67251d536.gif)
